### PR TITLE
fix: correct filter logic for completed tasks

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -32,10 +32,9 @@ function App() {
     // TODO: Implement delete functionality
   };
 
-  // BUG: Filter logic is incorrect - 'completed' filter shows incomplete tasks
   const getFilteredTasks = () => {
     if (filter === 'completed') {
-      return tasks.filter((task) => !task.completed);
+      return tasks.filter((task) => task.completed);
     } else if (filter === 'active') {
       return tasks.filter((task) => !task.completed);
     }


### PR DESCRIPTION
## Summary

Fixes #1

## Problem

The "Completed" filter was showing incomplete tasks instead of completed ones.

## Root Cause

In `getFilteredTasks()`, the completed filter used `!task.completed` (negated) which returned incomplete tasks.

## Solution

Changed the filter condition from:
```js
return tasks.filter((task) => !task.completed);
```
to:
```js
return tasks.filter((task) => task.completed);
```

## Testing

1. Open the app
2. Create a mix of completed and incomplete tasks
3. Click "Completed" filter
4. Verify only completed tasks are shown