### PR TITLE
fix: correct typo in empty state message

### DIFF
--- a/src/components/TaskList.js
+++ b/src/components/TaskList.js
@@ -3,7 +3,7 @@ import TaskItem from './TaskItem';
 
 function TaskList({ tasks, onToggle, onDelete }) {
   if (tasks.length === 0) {
-    return <p>No taks to display</p>;
+    return <p>No tasks to display</p>;
   }
 
   return (


### PR DESCRIPTION
## Summary
Fixes the typo in the empty state message.

## Changes
- Changed "No taks to display" → "No tasks to display" in TaskList.js

## Testing
- Delete all tasks to see the empty state
- Verify the message now reads correctly

Fixes #8